### PR TITLE
allow option to specify tls key,cert for gw while connecting to grpc listener

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -113,7 +113,7 @@ func (l *Logger) initWrappedLogger() {
 		// Tee off logs to rollbar
 		zcores = append(zcores, newRollbarCore(l.rollbarToken, l.getEvironment(), l.getVersion(), l.rollbarMinLevel))
 	}
-	wl := zap.New(zapcore.NewTee(zcores...), zap.AddCaller(), zap.AddCallerSkip(1), zap.AddStacktrace(zap.WarnLevel))
+	wl := zap.New(zapcore.NewTee(zcores...), zap.AddCaller(), zap.AddCallerSkip(1), zap.AddStacktrace(zap.ErrorLevel))
 	l.wrappedLogger = wl.Named(l.name).Sugar()
 }
 

--- a/server/option.go
+++ b/server/option.go
@@ -124,6 +124,14 @@ func TLSCred(certFile, keyFile, clientCA string) Option {
 	})
 }
 
+// GatewayClientTLSCred Key and Cert file to be used by gateway client to connect to the gw server
+func GatewayClientTLSCred(certFile, keyFile string) Option {
+	return optionFunc(func(r *runtime) {
+		r.gwClientKeyFile = keyFile
+		r.gwClientCertFile = certFile
+	})
+}
+
 // GRPCAPI that needs to be registered with Runtime
 func GRPCAPI(handler GRPCAPIHandler, gw bool) Option {
 	return optionFunc(func(r *runtime) {

--- a/server/tls.go
+++ b/server/tls.go
@@ -72,17 +72,3 @@ func newClientCert() (cert tls.Certificate, err error) {
 
 	return clientCert, nil
 }
-
-func newTLSConfig() (*tls.Config, error) {
-
-	certificate, err := newClientCert()
-	if err != nil {
-		return nil, err
-	}
-	tc := &tls.Config{
-		Certificates:       []tls.Certificate{certificate},
-		InsecureSkipVerify: true,
-		NextProtos:         []string{"h1"},
-	}
-	return tc, nil
-}


### PR DESCRIPTION
- if gw option is enabled allow tls cert and key to be specified, this is need when the grpc server is run with mTLS
- close the grpc client connection first before shutting the grpc-gw server
- print stack trace only for error levels and above
