### PR TITLE
Change Logger to an interface.

### DIFF
--- a/auth/option.go
+++ b/auth/option.go
@@ -27,7 +27,7 @@ func ServiceName(serviceName string) Option {
 }
 
 // Logger for runtime
-func Logger(l *log.Logger) Option {
+func Logger(l log.Logger) Option {
 	return optionFunc(func(r *runtime) {
 		r.logger = l.NamedLogger("auth")
 	})

--- a/auth/runtime.go
+++ b/auth/runtime.go
@@ -72,7 +72,7 @@ type Runtime interface {
 }
 
 type runtime struct {
-	logger *log.Logger
+	logger log.Logger
 
 	appName     string // app name passed as part of the authz request
 	serviceName string // service name used as part of the authz request

--- a/health/option.go
+++ b/health/option.go
@@ -44,7 +44,7 @@ func FailureSleepInterval(duration time.Duration) Option {
 }
 
 // Logger configures logger for health service
-func Logger(l *log.Logger) Option {
+func Logger(l log.Logger) Option {
 	return optionFunc(func(hc *healthChecker) {
 		hc.logger = l.NamedLogger("health")
 	})

--- a/health/service.go
+++ b/health/service.go
@@ -31,7 +31,7 @@ type (
 
 	healthChecker struct {
 		server               *http.Server
-		logger               *log.Logger
+		logger               log.Logger
 		probes               map[string]Probe
 		quit                 chan bool
 		bindAddress          string

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -32,14 +32,14 @@ func TestNew(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		matcher func(l *Logger) bool
+		matcher func(l *logger) bool
 	}{
 		{
-			"case-1", args{[]Option{WithFormat(JSON)}}, func(l *Logger) bool {
+			"case-1", args{[]Option{WithFormat(JSON)}}, func(l *logger) bool {
 				return l.format == JSON
 			}},
 		{
-			"case-2", args{[]Option{WithTags(map[string]string{"environment": "dev", "version": "v1.2"})}}, func(l *Logger) bool {
+			"case-2", args{[]Option{WithTags(map[string]string{"environment": "dev", "version": "v1.2"})}}, func(l *logger) bool {
 				return l.getEvironment() == "dev" && l.getVersion() == "v1.2"
 			}},
 	}
@@ -61,10 +61,10 @@ func TestLogger_NamedLogger(t *testing.T) {
 	tests := []struct {
 		name    string
 		lName   string
-		matcher func(l *Logger) bool
+		matcher func(l *logger) bool
 	}{
 		{
-			"nammed-sub-logger", "sub-logger", func(l *Logger) bool {
+			"nammed-sub-logger", "sub-logger", func(l *logger) bool {
 				return l.name == "sub-logger"
 			},
 		},
@@ -76,7 +76,7 @@ func TestLogger_NamedLogger(t *testing.T) {
 				t.Errorf("New() error = %v, wantErr nil", err)
 				return
 			}
-			if got := l.NamedLogger(tt.lName); !tt.matcher(got) {
+			if got := l.NamedLogger(tt.lName).(*logger); !tt.matcher(got) {
 				t.Errorf("Logger.NamedLogger() = %q, want %q", got.name, tt.lName)
 			}
 		})

--- a/log/option.go
+++ b/log/option.go
@@ -2,35 +2,35 @@ package log
 
 // WithName sets logger name
 func WithName(name string) Option {
-	return optionFunc(func(l *Logger) {
+	return optionFunc(func(l *logger) {
 		l.name = name
 	})
 }
 
 // WithLevel sets level for the logger
 func WithLevel(level Level) Option {
-	return optionFunc(func(l *Logger) {
+	return optionFunc(func(l *logger) {
 		l.level = level
 	})
 }
 
 // WithFormat sets log Formatter
 func WithFormat(format Format) Option {
-	return optionFunc(func(l *Logger) {
+	return optionFunc(func(l *logger) {
 		l.format = format
 	})
 }
 
 // WithTags sets logger's tags
 func WithTags(tags map[string]string) Option {
-	return optionFunc(func(l *Logger) {
+	return optionFunc(func(l *logger) {
 		l.tags = tags
 	})
 }
 
 // WithRollbar enables critical logging to rollbar
 func WithRollbar(token string, minLevel Level) Option {
-	return optionFunc(func(l *Logger) {
+	return optionFunc(func(l *logger) {
 		l.rollbarToken = token
 		l.rollbarMinLevel = minLevel
 	})

--- a/server/option.go
+++ b/server/option.go
@@ -31,7 +31,7 @@ func Probes(probes map[string]health.Probe) Option {
 }
 
 // Logger for runtime
-func Logger(l *log.Logger) Option {
+func Logger(l log.Logger) Option {
 	return optionFunc(func(r *runtime) {
 		r.logger = l.NamedLogger("rt")
 	})


### PR DESCRIPTION
Makes it easier to swap out the logger _and_ conforms to the “Accept interfaces, return structs” approach